### PR TITLE
Added in psubscribe support

### DIFF
--- a/src/redo.erl
+++ b/src/redo.erl
@@ -28,7 +28,7 @@
          handle_info/2, terminate/2, code_change/3]).
 
 -export([start_link/0, start_link/1, start_link/2,
-         cmd/1, cmd/2, cmd/3, subscribe/1, subscribe/2]).
+         cmd/1, cmd/2, cmd/3, subscribe/1, subscribe/2, psubscribe/1, psubscribe/2]).
 
 -record(state, {host, port, pass, db, sock, queue, subscriber, cancelled, acc, buffer}).
 
@@ -104,6 +104,15 @@ subscribe(Channel) ->
 -spec subscribe(atom() | pid(), list() | binary()) -> reference() | {error, term()}.
 subscribe(NameOrPid, Channel) ->
     Packet = redo_redis_proto:package(["SUBSCRIBE", Channel]),
+    gen_server:call(NameOrPid, {subscribe, Packet}, 2000).
+
+-spec psubscribe(list() | binary()) -> reference() | {error, term()}.
+psubscribe(Channel) ->
+    subscribe(?MODULE, Channel).
+
+-spec psubscribe(atom() | pid(), list() | binary()) -> reference() | {error, term()}.
+psubscribe(NameOrPid, Channel) ->
+    Packet = redo_redis_proto:package(["PSUBSCRIBE", Channel]),
     gen_server:call(NameOrPid, {subscribe, Packet}, 2000).
 
 %%====================================================================

--- a/src/redo_redis_proto.erl
+++ b/src/redo_redis_proto.erl
@@ -146,6 +146,9 @@ read_line(<<>>, _Acc) ->
 read_line(<<C, Rest/binary>>, Acc) ->
     read_line(Rest, <<Acc/binary, C>>).
 
+multi_bulk(_Acc, -1, Rest) ->
+    {ok, undefined, {raw, Rest}};
+
 multi_bulk(Acc, 0, Rest) ->
     {ok, lists:reverse(Acc), {raw, Rest}};
 


### PR DESCRIPTION
So I didn't reinvent the wheel or anything like that, all I ended up doing was duplicating the subscribe function and make is send a psubscribe command to redis.
