### PR TITLE
redo -- blocking requests

### DIFF
--- a/src/redo.erl
+++ b/src/redo.erl
@@ -67,7 +67,7 @@ cmd(NameOrPid, Cmd) ->
 -spec cmd(atom() | pid(), list() | binary(), integer()) ->
                  response() | [response()].
 
-cmd(NameOrPid, Cmd, Timeout) when is_integer(Timeout) ->
+cmd(NameOrPid, Cmd, Timeout) when is_integer(Timeout); Timeout =:= infinity ->
     %% format commands to be sent to redis
     Packets = redo_redis_proto:package(Cmd),
 

--- a/src/redo_block.erl
+++ b/src/redo_block.erl
@@ -1,0 +1,188 @@
+%% Manages multiple requests and timers. May or may not kill it if the task
+%% takes too long, and then just start a new worker instead.
+%%
+%% Subscription mode isn't supported yet.
+-module(redo_block).
+-behaviour(gen_server).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2,
+         handle_info/2, terminate/2, code_change/3]).
+
+-export([start_link/0, start_link/1, start_link/2,
+         cmd/1, cmd/2, cmd/3, shutdown/1]).
+-export([reply/2]).
+
+-record(state, {opts=[], refs, acc,
+                worker, worker_status=free,
+                timers, queue}).
+
+-define(TIMEOUT, 5000).
+
+%%%%%%%%%%%%%%%%%
+%%% INTERFACE %%%
+%%%%%%%%%%%%%%%%%
+start_link() ->
+    start_link([]).
+
+start_link(Name) when is_atom(Name) ->
+    start_link(Name, []);
+start_link(Opts) when is_list(Opts) ->
+    start_link(?MODULE, Opts).
+
+start_link(undefined, Opts) when is_list(Opts) ->
+    gen_server:start_link(?MODULE, Opts, []);
+start_link(Name, Opts) when is_atom(Name), is_list(Opts) ->
+    gen_server:start_link({local, Name}, ?MODULE, Opts, []).
+
+
+cmd(Cmd) ->
+    cmd(?MODULE, Cmd, ?TIMEOUT).
+
+cmd(NameOrPid, Cmd) ->
+    cmd(NameOrPid, Cmd, ?TIMEOUT).
+
+cmd(NameOrPid, Cmd, Timeout) ->
+    %% format commands to be sent to redis | now done in the worker
+    %% Packets = redo_redis_proto:package(Cmd),
+    gen_server:call(NameOrPid, {cmd, Cmd, Timeout}, infinity).
+
+shutdown(NameOrPid) ->
+    gen_server:cast(NameOrPid, shutdown).
+
+reply({Pid, TimerRef}, Response) ->
+    gen_server:cast(Pid, {done, self(), TimerRef, Response}).
+
+%%%%%%%%%%%%%%%%%
+%%% CALLBACKS %%%
+%%%%%%%%%%%%%%%%%
+init(Opts) ->
+    process_flag(trap_exit, true), % deal with worker failures
+    {ok, Worker} = redo:start_link(undefined, Opts),
+    {ok, #state{opts=Opts,
+                worker=Worker, worker_status=free,
+                timers=gb_trees:empty(), queue=queue:new()}}.
+
+handle_call({cmd, Cmd, TimeOut}, From, S=#state{worker_status=free, timers=T, queue=Q}) ->
+    TimerRef = erlang:start_timer(TimeOut, self(), From),
+    handle_info(timeout, S#state{timers=gb_trees:insert(TimerRef, {From,Cmd}, T),
+                                 queue=queue:in(TimerRef,Q)});
+handle_call({cmd, Cmd, TimeOut}, From, S=#state{worker_status=busy, timers=T, queue=Q}) ->
+    TimerRef = erlang:start_timer(TimeOut, self(), From),
+    {noreply, S#state{timers=gb_trees:insert(TimerRef, {From,Cmd}, T),
+                      queue=queue:in(TimerRef,Q)}, 0}.
+
+handle_cast({done, TimerRef, Result}, S=#state{timers=T, queue=Q}) ->
+    erlang:cancel_timer(TimerRef),
+    case queue:out(Q) of
+        {empty, _} -> % response likely came too late
+            {noreply, S#state{worker_status=free, refs=undefined, acc=undefined}};
+        {{value,TimerRef}, Queue} -> % done, drop top element
+            {From, _} = gb_trees:get(TimerRef, T),
+            gen_server:reply(From, Result),
+            {noreply, S#state{worker_status = free,
+                              refs = undefined,
+                              acc = undefined,
+                              timers = gb_trees:delete(TimerRef, T),
+                              queue = Queue}, 0};
+        {{value,_Ref}, _} -> % race condition, timed out answer?
+            %% Let's clean up just in case
+            Queue = queue:filter(fun(Ref) -> Ref =/= TimerRef end, Q),
+            {noreply, S#state{worker_status = free,
+                              timers = gb_trees:delete_any(TimerRef, T),
+                              queue = Queue}, 0}
+    end;
+handle_cast(shutdown, State) ->
+    {stop, {shutdown,cast}, State}.
+
+handle_info(timeout, S=#state{worker_status=busy}) ->
+    %% Task scheduled. We'll get a message when it's done
+    {noreply, S};
+handle_info(timeout, S=#state{worker_status=free}) ->
+    case schedule(S) of
+        {ok, State} ->  {noreply, State};
+        {error, Reason} -> {stop, {worker,Reason}, S}
+    end;
+handle_info({timeout, TimerRef, From}, S=#state{worker=Pid, timers=T, queue=Q}) ->
+    case queue:out(Q) of
+        {empty, _} -> % potential bad timer management?
+            {noreply, S};
+        {{value,TimerRef}, Queue} -> % currently being handled
+            unlink(Pid),
+            exit(Pid, shutdown),
+            {From, _} = gb_trees:get(TimerRef, T),
+            gen_server:reply(From, {error, timeout}),
+            case schedule(S#state{worker = undefined,
+                                  worker_status = free,
+                                  refs = undefined,
+                                  acc = undefined,
+                                  timers = gb_trees:delete(TimerRef, T),
+                                  queue = Queue}) of
+                {ok, State} -> {noreply, State};
+                {error, Reason} -> {stop, {worker,Reason}, S}
+            end;
+        {_, _} -> % somewhere in the queue, or maybe not if raced before cancel
+            case gb_trees:lookup(TimerRef, T) of
+                none ->
+                    {noreply, S};
+                {value, {From, _}} -> % same as the one we got
+                    gen_server:reply(From, {error, timeout}),
+                    Queue = queue:filter(fun(Ref) -> Ref =/= TimerRef end, Q),
+                    {noreply, S#state{timers = gb_trees:delete(TimerRef, T),
+                                      queue = Queue}}
+            end
+    end;
+handle_info({'EXIT', Pid, _Reason}, S=#state{worker=Pid}) ->
+    %% The worker died. We retry until the timeout fails and the task is pulled
+    %% from the queue.
+    case schedule(S#state{worker=undefined, worker_status=free,
+                          refs=undefined, acc=undefined}) of
+        {ok, State} -> {noreply, State};
+        {error, Reason} -> {stop, {worker, Reason}, S}
+    end;
+
+%% Handling responses from redo
+handle_info({Ref, Val}, S=#state{refs=[Ref], acc=Acc, queue=Q}) ->
+    {value, TimerRef} = queue:peek(Q),
+    Result = case Val of
+        closed -> lists:reverse([{error,closed} | Acc]);
+        _ -> lists:reverse([Val|Acc])
+    end,
+    gen_server:cast(self(), {done, TimerRef, Result}),
+    {noreply, S#state{refs=undefined, acc=undefined}};
+handle_info({Ref, closed}, S=#state{refs=[Ref|Refs], acc=Acc}) ->
+    {noreply, S#state{refs=Refs, acc=[{error, closed} | Acc]}};
+handle_info({Ref, Val}, S=#state{refs=[Ref|Refs], acc=Acc}) ->
+    {noreply, S#state{refs=Refs, acc=[Val | Acc]}};
+handle_info({_BadRef,_}, State) ->
+    {noreply, State}.
+
+terminate(_, #state{worker=undefined}) ->
+    ok;
+terminate(_, #state{worker=Pid}) ->
+    exit(Pid, shutdown),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%%%%%%%%%%%%%
+%%% PRIVATE %%%
+%%%%%%%%%%%%%%%
+schedule(S=#state{worker=undefined, opts=Opts}) ->
+    case redo:start_link(undefined, Opts) of
+        {ok, Worker} ->
+            schedule(S#state{worker=Worker, worker_status=free});
+        {stop, Err} ->
+            {error, Err}
+    end;
+schedule(S=#state{worker=Pid, worker_status=free, timers=T, queue=Q}) ->
+    case queue:peek(Q) of
+        empty -> % nothing to schedule, keep idling.
+            {ok, S};
+        {value,TimerRef} ->
+            {_From, Cmd} = gb_trees:get(TimerRef, T),
+            Refs = redo:async_cmd(Pid, Cmd),
+            {ok, S#state{worker_status=busy, refs=Refs, acc=[]}}
+    end.
+

--- a/test/redo_block_tests.erl
+++ b/test/redo_block_tests.erl
@@ -1,0 +1,160 @@
+-module(redo_block_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% copy/pasted
+-record(state, {opts=[], refs, acc,
+                worker, worker_status=free,
+                timers, queue}).
+
+-ifndef(HOST).
+-define(HOST, "127.0.0.1").
+-endif.
+
+-ifndef(PORT).
+-define(PORT, 6379).
+-endif.
+
+-ifndef(PASSWORD).
+-define(PASSWORD, undefined).
+-endif.
+
+-ifndef(DB).
+-define(DB, undefined).
+-endif.
+
+config() ->
+    %% This suite assumes there is a local redis available. Can be defined
+    %% through macros.
+    [{host, ?HOST}, {port, ?PORT}] ++
+     case ?PASSWORD of
+         undefined -> [];
+         _ -> [{pass, ?PASSWORD}]
+     end ++
+     case ?DB of
+         undefined -> [];
+         _ -> [{db, ?DB}]
+     end.
+
+start() ->
+    application:start(sasl),
+    {ok, Pid} = redo_block:start_link(undefined, config()),
+    unlink(Pid),
+    Pid.
+
+stop(Pid) ->
+    redo_block:shutdown(Pid).
+
+seq_test_() ->
+    {"Try basic commands in sequence, try to get the right value",
+     {setup,
+      fun start/0,
+      fun stop/1,
+      fun(Pid) ->
+        Key = lists:flatten(io_lib:format("~p-~p", [make_ref(),now()])),
+        Cmds = [redo_block:cmd(Pid, ["EXISTS", Key]),
+                redo_block:cmd(Pid, ["SET", Key, "1"]),
+                redo_block:cmd(Pid, ["GET", Key]),
+                redo_block:cmd(Pid, ["SET", Key, "2"]),
+                redo_block:cmd(Pid, ["GET", Key]),
+                redo_block:cmd(Pid, ["DEL", Key]),
+                redo_block:cmd(Pid, ["EXISTS", Key])],
+        ?_assertEqual([0, <<"OK">>, <<"1">>, <<"OK">>, <<"2">>, 1, 0],
+                      [Cmd || [Cmd] <- Cmds])
+      end}}.
+
+parallel_test_() ->
+    {"Running tests in parallel. They end up being sequential, but all the "
+     "results should be in the right order.",
+     {setup,
+      fun start/0,
+      fun stop/1,
+      fun(Pid) ->
+        Parent = self(),
+        Keygen = fun() ->
+            iolist_to_binary(io_lib:format("~p-~p", [make_ref(),now()]))
+        end,
+        %% Takes a unique key, inserts it, then reads it. With hundreds of concurrent
+        %% processes, if redo_block doesn't behave well, the val read might be different
+        %% from the val written.
+        Proc = fun() ->
+            Key = Keygen(),
+            redo_block:cmd(Pid, ["SET", Key, Key]),
+            R = case redo_block:cmd(Pid, ["GET", Key]) of
+                [Res] -> Res;
+                Tup when is_tuple(Tup) -> Tup
+            end,
+            redo_block:cmd(Pid, ["DEL", Key]),
+            Parent ! {Key, R}
+        end,
+        N = 10000,
+        _ = [spawn_link(Proc) || _ <- lists:seq(1,N)],
+        Res = [receive Msg -> Msg end || _ <- lists:seq(1,N)],
+        ?_assertEqual(N, length([ok || {Key,Key} <- Res]))
+      end}}.
+
+timeout_test_() ->
+    {"A request timeout should kill the connection and start a new one "
+     "without necessarily killing follow-up requests or messing up "
+     "with the final ordering of responses",
+     {setup,
+      fun start/0,
+      fun stop/1,
+      fun(Pid) ->
+        Key = lists:flatten(io_lib:format("~p-~p", [make_ref(),now()])),
+        Cmds = [redo_block:cmd(Pid, ["EXISTS", Key]),
+                redo_block:cmd(Pid, ["SET", Key, "1"]),
+                redo_block:cmd(Pid, ["GET", Key], 0),
+                redo_block:cmd(Pid, ["SET", Key, "2"]),
+                redo_block:cmd(Pid, ["GET", Key]),
+                redo_block:cmd(Pid, ["DEL", Key]),
+                redo_block:cmd(Pid, ["EXISTS", Key])],
+        ?_assertMatch([[0], [<<"OK">>], _TimeoutOrVal, [<<"OK">>], [<<"2">>], [1], [0]],
+                      Cmds)
+      end}}.
+
+parallel_timeout_test_() ->
+    {"Running tests in parallel. They end up being sequential, but all the "
+     "results should be in the right order, even if requests time out all "
+     "the time.",
+     {setup,
+      fun start/0,
+      fun stop/1,
+      fun(Pid) ->
+        Parent = self(),
+        Keygen = fun() ->
+            iolist_to_binary(io_lib:format("~p-~p", [make_ref(),now()]))
+        end,
+        %% Takes a unique key, inserts it, then reads it. With hundreds of concurrent
+        %% processes, if redo_block doesn't behave well, the val read might be different
+        %% from the val written.
+        Proc = fun() ->
+            Key = Keygen(),
+            redo_block:cmd(Pid, ["SET", Key, Key], 30000),
+            [R1] = redo_block:cmd(Pid, ["GET", Key], 30000),
+            R2 = case redo_block:cmd(Pid, ["GET", Key], 0) of
+                [Res] -> Res;
+                Tup when is_tuple(Tup) -> Tup
+            end,
+            [R3] = redo_block:cmd(Pid, ["GET", Key], 30000),
+            redo_block:cmd(Pid, ["DEL", Key], 60000),
+            Parent ! {Key,R1,R2,R3}
+        end,
+        N = 10000,
+        _ = [spawn_link(Proc) || _ <- lists:seq(1,N)],
+        Res = [receive Msg -> Msg end || _ <- lists:seq(1,N)],
+        ?_assertEqual(N, length([ok || {Key,Key,TimeoutOrVal,Key} <- Res,
+                                       TimeoutOrVal == {error,timeout} orelse
+                                       TimeoutOrVal == Key]))
+      end}}.
+
+timeout_new_conn_test() ->
+    Pid = start(),
+    {_,_,_,Props1} = sys:get_status(Pid),
+    _ = [redo_block:cmd(Pid, ["EXISTS", "1"], 0) || _ <- lists:seq(1,1000)],
+    {_,_,_,Props2} = sys:get_status(Pid),
+    stop(Pid),
+    [#state{worker=Pid1}] = [State || X = [_|_] <- Props1,
+                                      {data,[{"State", State}]} <- X],
+    [#state{worker=Pid2}] = [State || X = [_|_] <- Props2,
+                                      {data,[{"State", State}]} <- X],
+    ?assertNotEqual(Pid1, Pid2).


### PR DESCRIPTION
redo_block aims to add the same cmd/1-3 functionality redo allows, but
while disabling pipelining.

The reason for this is that in some cases, it becomes difficult to
measure the time a request takes and to allow individual timeouts from
request/response when everything gets to be sequential.

redo_block instead buffers the requests locally on a gen_server that
starts timers ASAP and will make sure only one request at a time is sent
over a connection. This is much slower than pipelining, but allows a
more granular control over failures.
