### PR TITLE
don't fail to init() and keep reconnecting if reconnect is true

### DIFF
--- a/src/redo.erl
+++ b/src/redo.erl
@@ -138,7 +138,15 @@ init([Opts]) ->
         State1 when is_record(State1, state) ->
             {ok, State1};
         Err ->
-            {stop, Err}
+            case State#state.reconnect of
+                true ->
+                    erlang:send_after(1000, self(), timeout),
+                    ?WARN("redo init error: ~p", [Err]),
+                    {ok, State#state{sock=undefined}};
+                _ ->
+                    {stop, Err}
+            end
+            
     end.
 
 %%--------------------------------------------------------------------

--- a/src/redo.erl
+++ b/src/redo.erl
@@ -140,9 +140,8 @@ init([Opts]) ->
         Err ->
             case State#state.reconnect of
                 true ->
-                    erlang:send_after(1000, self(), timeout),
                     ?WARN("redo init error: ~p", [Err]),
-                    {ok, State#state{sock=undefined}};
+                    {ok, State#state{sock=undefined}, 1000};
                 _ ->
                     {stop, Err}
             end


### PR DESCRIPTION
This patch makes redo keep reconnecting even if Redis server is not ready when redo:init is called.
