### PR TITLE
Fix typespec for cmd

### DIFF
--- a/src/redo.erl
+++ b/src/redo.erl
@@ -64,7 +64,7 @@ cmd(NameOrPid, Cmd) ->
     cmd(NameOrPid, Cmd, ?TIMEOUT).
 
 -type redis_value() :: integer() | binary().
--type response() :: redis_value() | [redis_value()] | {'error', Reason::term()}.
+-type response() :: redis_value() | [redis_value()] | undefined | {'error', Reason::term()}.
 
 -spec cmd(atom() | pid(), list() | binary(), integer()) ->
                  response() | [response()].


### PR DESCRIPTION
Error reported by Dialyzer when I was using `redo` as dependency.
